### PR TITLE
Added missing string 'CallerName' to Feature class

### DIFF
--- a/src/simpleModels/Features.php
+++ b/src/simpleModels/Features.php
@@ -20,6 +20,7 @@ class Feature {
 
     protected $fields = array(
         "Status" => array("type" => "string"),
+        "CallerName" => array("type" => "string"),
         "SubscriberType" => array("type" => "string"),
         "SubscriberInformation" => array("type" => "string"),
         "UseType" => array("type" => "string"),


### PR DESCRIPTION
When pulling the tn details, the E911 record was missing the CallerName field in the output.