### PR TITLE
Fixing empty body not populating Exception message

### DIFF
--- a/core/Client.php
+++ b/core/Client.php
@@ -365,7 +365,7 @@ final class Client extends iClient
      */
     private function parseExceptionResponse($e)
     {
-        $body = $e->getResponse()->getBody(true);
+        $body = $e->getResponse()->getBody(true)->getContents();
         $doc = @simplexml_load_string($body);
 
         if (isset($doc) &&
@@ -389,6 +389,6 @@ final class Client extends iClient
             );
         }
 
-        throw new ResponseException($body, $e->getResponse()->getStatusCode());
+        throw new ResponseException($e->getMessage(), $e->getResponse()->getStatusCode());
     }
 }

--- a/tests/BadCredsTest.php
+++ b/tests/BadCredsTest.php
@@ -1,0 +1,39 @@
+<?php
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Middleware;
+
+class BadCredsTest extends PHPUnit_Framework_TestCase {
+    public static $container;
+    public static $client;
+    public static $index = 0;
+
+    public static function setUpBeforeClass() {
+        $mock = new MockHandler([
+            new Response(401, [], ""),
+        ]);
+
+        self::$container = [];
+        $history = Middleware::history(self::$container);
+        $handler = HandlerStack::create($mock);
+        $handler->push($history);
+
+        self::$client = new Iris\Client("test", "test", Array('url' => 'https://test.dashboard.bandwidth.com/', 'handler' => $handler));
+    }
+
+    /**
+     * @expectedException   Iris\ResponseException
+     * @expectedExceptionMessageRegExp #^.*resulted in a.*$#
+     * @expectedExceptionCode 401
+     */
+    public function testAuthFail() {
+        $c = new \Iris\Cities(self::$client);
+        try {
+            $cities = $c->getList(["state" => "NC"]);
+        } catch (ClientException $e) {
+            $this->assertTrue(!empty($e->getMessage()));
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
Today I was trying to test out some code but my Bandwidth Test creds were incorrect. The ClientException was thrown, but because the Iris\ResponseException populates the message with the `$body` rather than the message from the exception, `$exception->getMessage()` returned nothing helpful. 

This modifies `parseExceptionResponse()` to:

1. explicitly set `$body` to a string rather than having the object convert on the fly
2. If `$body` doesn't contain anything in the response or error sections, simply pass the Exception message that raised it in the first place to pass it through to the client

Tests are written, they fail before the change and pass after. 