### PR TITLE
#48 fix(ErrorParsing) - added case for Errors parameter name parsing

### DIFF
--- a/core/Client.php
+++ b/core/Client.php
@@ -390,6 +390,17 @@ final class Client extends iClient
             );
         }
 
+        if (isset($doc) &&
+            isset($doc->Errors) &&
+            isset($doc->Errors->Description) &&
+            isset($doc->Errors->Code))
+        {
+            throw new ResponseException(
+                (string) $doc->Errors->Description,
+                (int) $doc->Errors->Code
+            );
+        }
+
         throw new ResponseException($e->getMessage(), $e->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
Fix issue https://github.com/Bandwidth/php-bandwidth-iris/issues/48 - incorrect error parsing.

More details and how to reproduce in the issue description https://github.com/Bandwidth/php-bandwidth-iris/issues/48