### PR TITLE
Check isset on CoveredRateCenter key

### DIFF
--- a/src/CoveredRateCenter.php
+++ b/src/CoveredRateCenter.php
@@ -13,7 +13,7 @@ final class CoveredRateCenters extends RestEntry{
         $rcs = [];
         $data = parent::_get('coveredRateCenters', $filters, Array("page"=> 1, "size" => 30), Array("page", "size"));
 
-        if($data['CoveredRateCenter']) {
+        if(isset($data['CoveredRateCenter'])) {
             $items =  $data['CoveredRateCenter'];
 
             if($this->is_assoc($items))


### PR DESCRIPTION
Certain states/provinces do not have any rate centers available and thus this returns an error

`PHP Notice:  Undefined index: CoveredRateCenter in /usr/src/telephony/vendor/bandwidth/iris/src/CoveredRateCenter.php on line 16`

You can check from:
* NH
* NL
* NU