### PR TITLE
feat(Client) - added option to get last response body from client object

### DIFF
--- a/core/Client.php
+++ b/core/Client.php
@@ -125,6 +125,9 @@ abstract class iClient
 final class Client extends iClient
 {
 
+    /**
+     * Store the last response body string 
+     */
     protected $lastResponseBody = null;
 
     public function __construct($login, $password, $options = [])
@@ -291,7 +294,7 @@ final class Client extends iClient
 
     /**
      * Returns the XML string received in the last response.
-     * @return type
+     * @return string $lastResponseBody
      */
     public function getLastResponseBody() {
         return $this->lastResponseBody;

--- a/core/Client.php
+++ b/core/Client.php
@@ -124,6 +124,9 @@ abstract class iClient
 
 final class Client extends iClient
 {
+
+    protected $lastResponseBody = null;
+
     public function __construct($login, $password, $options = [])
     {
         if (empty($login) || empty($password))
@@ -270,6 +273,7 @@ final class Client extends iClient
      */
     public function request($method, $url, $options = [], $parse = true)
     {
+        $this->lastResponseBody = null;
         try
         {
             $response = $this->client->request($method, ltrim($url, '/'), $options);
@@ -283,6 +287,14 @@ final class Client extends iClient
         {
             $this->parseExceptionResponse($e);
         }
+    }
+
+    /**
+     * Returns the XML string received in the last response.
+     * @return type
+     */
+    public function getLastResponseBody() {
+        return $this->lastResponseBody;
     }
 
     /**
@@ -335,6 +347,7 @@ final class Client extends iClient
         }
 
         $responseBody = (string) $response->getBody();
+        $this->lastResponseBody = $responseBody;
 
         if (!$responseBody)
         {


### PR DESCRIPTION
Added option to store response body in class variable and get it by getLastResponseBody() function.
This is needed for example to log response data.

Same functionality exists in:

- PHP Soap: https://www.php.net/manual/en/soapclient.getlastresponse.php 
- Zend Framework: https://framework.zend.com/apidoc/1.12/classes/Zend_Http_Client.html#method_getLastResponse

## Usage

```PHP
$client = new \Iris\Client($login, $password, ['url' => 'https://dashboard.bandwidth.com/api/']);
$account = new \Iris\Account($your_account_id, $client);
$account->availableNumbers([ "areaCode" => "818" ]);
$lastResponse = $client->getLastResponseBody();
```
$lastResponse = 
` <?xml version="1.0" encoding="UTF-8" standalone="yes"?><SearchResult><ResultCount>2</ResultCount><TelephoneNumberList><TelephoneNumber>8182132977</TelephoneNumber><TelephoneNumber>8182728306</TelephoneNumber></TelephoneNumberList></SearchResult>`