### PR TITLE
Update SipPeerTelephoneNumber to enable/disabe SMS

### DIFF
--- a/src/simpleModels/SipPeerTelephoneNumber.php
+++ b/src/simpleModels/SipPeerTelephoneNumber.php
@@ -10,7 +10,8 @@ class SipPeerTelephoneNumber {
         "CallForward" => array("type" => "string"),
         "NumberFormat" => array("type" => "string"),
         "RPIDFormat" => array("type" => "string"),
-        "RewriteUser" => array("type" => "string")
+        "RewriteUser" => array("type" => "string"),
+        "MessagingSettings" => array("type" => "\Iris\MessageSettings")
     );
 
     public function __construct($data) {


### PR DESCRIPTION
Enable SMS on a TN is ignored due to missing MessageSettings attribute in SipPeerTelephoneNumber.
The class defined in simpleModels/SipPeerTelephoneNumber.php is missing the MessageSettings attribute, so when attempting to set $data["MessagingSettings"]["SmsEnabled"]= "true", this is ignored.

Adding the field and type to the SipPeerTelephoneNumber class allows for enabling/disabling SMS.