### PR TITLE
Fixes Issue #78 using PUT for set_activation_status()

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ PHP Client library for Bandwidth's Phone Number Dashboard (AKA: Dashboard, Iris)
 | 3.2.0 | Update SipPeerTelephoneNumber to enable/disabe SMS |
 | 3.3.0 | Added PortOutStatus, ActualFocDate, and SPID to the portout model |
 | 3.3.1 | Updated the portins update method to clear the ActualFocDate field |
+| 3.3.2 | Updated the portins set_activation_status method use a PUT method |
 
 ## Supported PHP Versions
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Bandwidth's Iris SDK for PHP",
     "keywords": ["iris","sdk","php"],
     "homepage": "http://dev.bandwidth.com",
-    "reference": "v3.3.1",
+    "reference": "v3.3.2",
     "license": "MIT",
     "authors": [
     ],
@@ -25,4 +25,3 @@
         ]
     }
 }
-

--- a/src/PortinsModel.php
+++ b/src/PortinsModel.php
@@ -193,7 +193,7 @@ class Portin extends RestEntry {
     public function set_activation_status($data) {
         $obj = new \Iris\ActivationStatus($data);
         $url = sprintf('%s/%s', $this->get_id(), 'activationStatus');
-        $res = parent::post($url, "ActivationStatus", $obj->to_array());
+        $res = parent::put($url, "ActivationStatus", $obj->to_array());
         return new ActivationStatus($res['ActivationStatus']);
     }
 


### PR DESCRIPTION
Fixes issue #78 using **PUT** for `set_activation_status()`

Consider a second set of tests that run against the dev server live! This could have been caught there. I know you may be rewriting the SDK so maybe that won't happen, but if this is sticking around for another few months, it may be worth the time.