### PR TITLE
SWI-2827 Add Repo to Service Catalog

### DIFF
--- a/.bandwidth/catalog-info.yaml
+++ b/.bandwidth/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+  schemaVersion: v1.0.0
+  name: php-bandwidth-iris-location
+  description: Links to additional entities in the php-bandwidth-iris repository.
+  annotations:
+    github.com/project-slug: Bandwidth/php-bandwidth-iris
+spec:
+  targets:
+    - ./component.yaml

--- a/.bandwidth/component.yaml
+++ b/.bandwidth/component.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  schemaVersion: v1.0.0
+  name: php-bandwidth-iris
+  description: PHP Library for Bandwidth's Phone Number Dashboard (AKA Dashboard, Iris)
+  annotations:
+    github.com/project-slug: Bandwidth/php-bandwidth-iris
+    organization: BW
+    costCenter: Development - Software Infra
+spec:
+  type: Infrastructure as Code
+  owner: github/band-swi
+  lifecycle: Available


### PR DESCRIPTION
Auto-generated by the Backstage Service Catalog. Adds a catalog-info.yaml Location and component.yaml Component to represent this repository.